### PR TITLE
Keep the Whoosh search index out of GlusterFS

### DIFF
--- a/common.tpl
+++ b/common.tpl
@@ -90,7 +90,8 @@ kpi:
   volumes:
     - "${VOL_WB}/static/kpi:/srv/static"
     # The Whoosh search index needs persistent storage
-    - "${VOL_DB}/whoosh:/srv/whoosh"
+    # ...but keep it away from glusterfs!
+    - "${VOL_WB}/../whoosh:/srv/whoosh"
 
 web:
   image: teodorescuserban/kobo-nginx:latest # still WIP


### PR DESCRIPTION
The search index receives heavy writes during imports, which overwhelm GlusterFS and starve other services. The new location of the search index follows the example of nginx logs, which are also excluded from GlusterFS.

This change was discussed at https://www.flowdock.com/app/unocha/kobotoolbox/threads/lWsnvoqaLUeE4ICUJKOUJDLG8ws. It was applied to `wb01` in February.